### PR TITLE
fix: easier to click on New Zealand

### DIFF
--- a/frontend/game.css
+++ b/frontend/game.css
@@ -2,7 +2,7 @@ aside {
   width: 13vw;
   padding: 1vw;
   position: absolute;
-  bottom: 0;
+  top: 0;
   right: 0;
   z-index: 999;
   background-color: rgba(0, 0, 0, 0.75);

--- a/frontend/game.js
+++ b/frontend/game.js
@@ -27,8 +27,8 @@ const map = L.map("map", {
   maxZoom: 5,
   scrollWheelZoom: true,
   maxBounds: [
-    [89.9, 160.9],
-    [-89.9, -160.9],
+    [-90, -180],
+    [90, 180],
   ],
   zoomControl: false,
   noWrap: true,


### PR DESCRIPTION
Fixed by doing two things:

1. Increase the limit of how far you can go with the map, according to the max limits of latitude and longitude.
2.  Moving leaderboard to the top, not disturbing too much of the map.

Fixes #82