### PR TITLE
dx: remove deprecated extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "rust-lang.rust-analyzer",
-    "serayuzgur.crates",
-    "tamasfe.even-better-toml"
-  ]
+  "recommendations": ["rust-lang.rust-analyzer", "tamasfe.even-better-toml"]
 }


### PR DESCRIPTION
The VSCode extension is considered deprecated